### PR TITLE
Update the time and link issues to the current repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Open Source Show and Tell
-## Friday June 9th, 2017 in San Francisco, CA from 1pm - 5pm
+
+## Friday June 9th, 2017 in San Francisco, CA from 1pm - 6pm
 [Website](http://opensourceshowandtell.com/) & [Eventbrite Page](https://www.eventbrite.com/e/open-source-show-tell-2017-tickets-34701040747)
 
-### [Submit a topic for a speaking spot](https://github.com/OpenSourceShowAndTell/SanFrancisco_April2015/issues/new)
+### [Submit a topic for a speaking spot](/issues/new)
 
-### [Code of Conduct](https://github.com/keen/community-code-of-conduct) (Please feel free to make suggestions or edits to our code of conduct via pull requests)
+### [Code of Conduct](https://github.com/keen/community-code-of-conduct) 
+Please feel free to make suggestions or edits to our code of conduct via pull requests

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Friday June 9th, 2017 in San Francisco, CA from 1pm - 6pm
 [Website](http://opensourceshowandtell.com/) & [Eventbrite Page](https://www.eventbrite.com/e/open-source-show-tell-2017-tickets-34701040747)
 
-### [Submit a topic for a speaking spot](/issues/new)
+### [Submit a topic for a speaking spot](/../../issues/new)
 
 ### [Code of Conduct](https://github.com/keen/community-code-of-conduct) 
 Please feel free to make suggestions or edits to our code of conduct via pull requests


### PR DESCRIPTION
The link to submit a talk was going to the repo back from 2015